### PR TITLE
New order action tag

### DIFF
--- a/config.json
+++ b/config.json
@@ -66,8 +66,8 @@
         },
         {
             "tag": "@INSTANCETABLE_ORDER",
-            "description": "Use <code>@INSTANCETABLE_ORDER</code> to hide the link to the repeating form in the Project Setup section of the project page menu. i.e.<code>@INSTANCETABLE_ORDER='3:desc'</code> to sort the table by the third column in descending order. The direction can be 'asc' or 'desc' (case-insensitive).If the action tag is not provided, it will default to sorting by column 1 in descending order (current behavior)"
-        },
+            "description": "Use <code>@INSTANCETABLE_ORDER</code> to hide the link to the repeating form in the Project Setup section of the project page menu. i.e.<code>@INSTANCETABLE_ORDER=3:desc</code> to sort the table by the third column in descending order. The direction can be 'asc' or 'desc' (case-insensitive).If the action tag is not provided, it will default to sorting by column 1 in descending order"
+        }
     ],
     "system-settings": [ ],
     "project-settings": [ ]

--- a/config.json
+++ b/config.json
@@ -63,7 +63,11 @@
         {
             "tag": "@INSTANCETABLE-HIDEFORMINMENU",
             "description": "Use <code>@INSTANCETABLE-HIDEFORMINMENU</code> to hide the link to the repeating form in the Data Collection section of the project page menu."
-        }
+        },
+        {
+            "tag": "@INSTANCETABLE_ORDER",
+            "description": "Use <code>@INSTANCETABLE_ORDER</code> to hide the link to the repeating form in the Project Setup section of the project page menu. i.e.<code>@INSTANCETABLE_ORDER='3:desc'</code> to sort the table by the third column in descending order. The direction can be 'asc' or 'desc' (case-insensitive).If the action tag is not provided, it will default to sorting by column 1 in descending order (current behavior)"
+        },
     ],
     "system-settings": [ ],
     "project-settings": [ ]


### PR DESCRIPTION
Use <code>@INSTANCETABLE_ORDER</code> to hide the link to the repeating form in the Project Setup section of the project page menu. i.e.<code>@INSTANCETABLE_ORDER=3:desc</code> to sort the table by the third column in descending order. The direction can be 'asc' or 'desc' (case-insensitive).If the action tag is not provided, it will default to sorting by column 1 in descending order"